### PR TITLE
Updated in-toto-java dependency from 0.3 to 0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,31 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>4.19</version>
     <relativePath />
   </parent>
-  <groupId>io.jenkins.plugins</groupId>
+  
   <artifactId>in-toto</artifactId>
   <version>0.3.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
+
   <properties>
-    <jenkins.version>2.303.1</jenkins.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jenkins.version>2.346.1</jenkins.version>
+    <bom>2.346.x</bom>
+    <bom.version>28</bom.version>
     <java.level>8</java.level>
+    <java.version>11</java.version>
+    <maven.compiler.release>${java.level}</maven.compiler.release>
+    <maven.compiler.source>${java.level}</maven.compiler.source>
+    <maven.compiler.target>${java.level}</maven.compiler.target>
+    <jenkins-test-harness.version>2.72</jenkins-test-harness.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <enforcer.skip>true</enforcer.skip>
   </properties>
   <name>in-toto provenance agent</name>
-    <description>
+  <description>
       This agent automatically tracks steps in a Jenkins pipeline and produces link metadata that corresponds to it.
-    </description>
+  </description>
   <licenses>
     <license>
       <name>MIT License</name>
-        <url>https://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
   <url>https://wiki.jenkins.io/display/JENKINS/in-toto+Plugin</url>
@@ -54,42 +64,19 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <dependencies>
 
+  <dependencies>
     <!-- in-toto: library to generate link metadata -->
     <dependency>
       <groupId>io.github.in-toto</groupId>
       <artifactId>in-toto</artifactId>
-      <version>0.3</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <!-- specify to avoid dependency conflicts -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.30</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.30</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.30</version>
+      <version>0.4.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.36.0</version>
+      <version>1.42.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -110,7 +97,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.9.0</version>
+      <version>4.2.3</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
@@ -118,39 +105,22 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.6.1.1</version>
+      <version>1129.vef26f5df883c</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.1</version>
+      <version>1.8</version>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.15</version>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <disabledTestInjection>true</disabledTestInjection>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/io/jenkins/plugins/intotorecorder/InTotoRecorder.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/InTotoRecorder.java
@@ -3,13 +3,6 @@
  */
 package io.jenkins.plugins.intotorecorder;
 
-import io.github.in_toto.models.Link;
-import io.github.in_toto.models.Artifact.ArtifactHash;
-import io.github.in_toto.models.Artifact;
-
-import io.github.in_toto.keys.Key;
-import io.github.in_toto.keys.RSAKey;
-
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.*;
@@ -18,6 +11,11 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.RunList;
+import io.github.intoto.legacy.keys.Key;
+import io.github.intoto.legacy.keys.RSAKey;
+import io.github.intoto.legacy.models.Artifact;
+import io.github.intoto.legacy.models.Link;
+import io.github.intoto.legacy.models.Artifact.ArtifactHash;
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
@@ -72,6 +70,7 @@ public class InTotoRecorder extends Recorder {
      *
      * If not defined signing will not be performed.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
     private String keyPath;
 
     /**
@@ -79,6 +78,7 @@ public class InTotoRecorder extends Recorder {
      *
      * If not defined signing will not be performed.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
     private String credentialId;
 
     /**
@@ -86,6 +86,7 @@ public class InTotoRecorder extends Recorder {
      *
      * If not defined, will default to step
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
     private String stepName;
 
     /**
@@ -93,6 +94,7 @@ public class InTotoRecorder extends Recorder {
      *
      * Protocol information *must* be included.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
     private String transport;
 
     /**
@@ -104,6 +106,7 @@ public class InTotoRecorder extends Recorder {
     /**
      * Loaded key used to sign metadata
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("UUF_UNUSED_FIELD")
     private Key key;
 
     /**
@@ -123,7 +126,7 @@ public class InTotoRecorder extends Recorder {
 
         /* notice how we can't do the same for the key, as that'd be a security
          * hazard */
-
+            
         this.credentialId = credentialId;
         this.keyPath = keyPath;
 

--- a/src/main/java/io/jenkins/plugins/intotorecorder/InTotoWrapper.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/InTotoWrapper.java
@@ -3,14 +3,12 @@
  */
 package io.jenkins.plugins.intotorecorder;
 
+import io.github.intoto.legacy.keys.Key;
+import io.github.intoto.legacy.keys.RSAKey;
+import io.github.intoto.legacy.models.Artifact;
+import io.github.intoto.legacy.models.Link;
+import io.github.intoto.legacy.models.Artifact.ArtifactHash;
 import io.jenkins.plugins.intotorecorder.transport.Transport;
-
-import io.github.in_toto.models.Link;
-import io.github.in_toto.models.Artifact.ArtifactHash;
-import io.github.in_toto.models.Artifact;
-
-import io.github.in_toto.keys.Key;
-import io.github.in_toto.keys.RSAKey;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -313,6 +311,7 @@ public class InTotoWrapper extends SimpleBuildWrapper {
         private static final long serialVersionUID = 2;
 
         String linkData;
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         String keyPath;
         String transportURL;
 
@@ -350,12 +349,13 @@ public class InTotoWrapper extends SimpleBuildWrapper {
     public static class PostWrap extends Disposer {
 
         private static final long serialVersionUID = 2;
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_TRANSIENT_FIELD_NOT_RESTORE")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORE")
         transient Link link;
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_TRANSIENT_FIELD_NOT_RESTORE")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORE")
         transient Key key;
         String keyPath;
         String transportURL;
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         String stepName;
 
         public PostWrap(Link link, Key key, String keyPath, String stepName,

--- a/src/main/java/io/jenkins/plugins/intotorecorder/transport/Etcd.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/transport/Etcd.java
@@ -7,12 +7,13 @@ import java.io.IOException;
 
 import java.net.URI;
 
-import io.github.in_toto.models.Link;
-
 // import com.coreos.jetcd.Client;
 // import com.coreos.jetcd.data.ByteSequence;
 
 import com.google.api.client.http.javanet.NetHttpTransport;
+
+import io.github.intoto.legacy.models.Link;
+
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
@@ -50,7 +51,7 @@ public class Etcd extends Transport {
                     ByteArrayContent.fromString("application/x-www-form-urlencoded",
                         "value=" + link.dumpString()));
 
-            HttpResponse response = request.execute();
+            request.execute();
         } catch (IOException e) {
             throw new RuntimeException("Couldn't serialize link: " +
                     link.getFullName() + ".Error was: " + e.toString());

--- a/src/main/java/io/jenkins/plugins/intotorecorder/transport/GenericCRUD.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/transport/GenericCRUD.java
@@ -5,11 +5,12 @@ package io.jenkins.plugins.intotorecorder.transport;
 
 import java.io.IOException;
 
-import io.github.in_toto.models.Link;
-
 import java.net.URI;
 
 import com.google.api.client.http.javanet.NetHttpTransport;
+
+import io.github.intoto.legacy.models.Link;
+
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.ByteArrayContent;

--- a/src/main/java/io/jenkins/plugins/intotorecorder/transport/GrafeasTransport.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/transport/GrafeasTransport.java
@@ -2,14 +2,14 @@
  *
  */
 package io.jenkins.plugins.intotorecorder.transport;
-
-import io.github.in_toto.models.Link;
-import io.github.in_toto.models.Artifact.ArtifactHash;
-import io.github.in_toto.keys.Signature;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import com.google.gson.Gson;
+
+import io.github.intoto.legacy.keys.Signature;
+import io.github.intoto.legacy.models.Link;
+import io.github.intoto.legacy.models.Artifact.ArtifactHash;
 
 import java.io.IOException;
 
@@ -29,9 +29,9 @@ public class GrafeasTransport extends Transport {
         // This class exists to represent the signed document format for Grafeas
         // in-toto links.
 
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         private ArrayList<Signature> signatures = new ArrayList<Signature>();
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         private GrafeasInTotoLink signed;
 
         private static class GrafeasInTotoLink {
@@ -39,9 +39,9 @@ public class GrafeasTransport extends Transport {
             // in-toto links.
 
             private static class Artifact {
-                @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+                @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
                 private String resourceUri;
-                @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+                @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
                 private Map<String, String> hashes;
 
                 private Artifact(String resourceUri, Map<String, String> hashes) {
@@ -51,11 +51,11 @@ public class GrafeasTransport extends Transport {
 
             }
 
-            @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+            @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
             private List<String> command = new ArrayList<String>();
-            @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+            @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
             private List<Artifact> materials = new ArrayList<Artifact>();
-            @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+            @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
             private List<Artifact> products = new ArrayList<Artifact>();
             private Map<String, Map<String, String>> byproducts = new HashMap<String, Map<String, String>>();
             private Map<String, Map<String, String>> environment = new HashMap<String, Map<String, String>>();
@@ -109,12 +109,12 @@ public class GrafeasTransport extends Transport {
 
 
     public static class GrafeasOccurrence {
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         private String noteName;
         private Map<String, String> resource = new HashMap<String, String>();
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         private String kind = "INTOTO";
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         private GrafeasInTotoMetadata intoto;
 
         public GrafeasOccurrence(String noteName, String resourceUri) {
@@ -142,7 +142,7 @@ public class GrafeasTransport extends Transport {
 
         Map<String, String> parameterMap = GrafeasTransport.getParameterMap(parameterString);
 
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("URF_UNREAD_FIELD")
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
         GrafeasOccurrence occurrence = new GrafeasOccurrence(
             parameterMap.get("noteName"),
             parameterMap.get("resourceUri")
@@ -164,7 +164,7 @@ public class GrafeasTransport extends Transport {
                 .buildPostRequest(this.uri,
                     ByteArrayContent.fromString("application/json",
                         jsonString));
-            HttpResponse response = request.execute();
+            request.execute();
 
             /* FIXME: should handle error codes and other situations more appropriately,
              * but this gets the job done for a PoC

--- a/src/main/java/io/jenkins/plugins/intotorecorder/transport/Redis.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/transport/Redis.java
@@ -4,8 +4,9 @@
 package io.jenkins.plugins.intotorecorder.transport;
 
 import redis.clients.jedis.Jedis;
-import io.github.in_toto.models.Link;
 import java.net.URI;
+
+import io.github.intoto.legacy.models.Link;
 
 public class Redis extends Transport {
 

--- a/src/main/java/io/jenkins/plugins/intotorecorder/transport/Transport.java
+++ b/src/main/java/io/jenkins/plugins/intotorecorder/transport/Transport.java
@@ -5,9 +5,8 @@ package io.jenkins.plugins.intotorecorder.transport;
 
 import java.net.URI;
 
-import io.github.in_toto.models.Link;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.intoto.legacy.models.Link;
 
 public abstract class Transport {
 

--- a/src/test/java/io/jenkins/plugins/intotorecorder/transport/EtcdTestIT.java
+++ b/src/test/java/io/jenkins/plugins/intotorecorder/transport/EtcdTestIT.java
@@ -6,6 +6,8 @@ package io.jenkins.plugins.intotorecorder.transport;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.util.RunList;
+import io.github.intoto.legacy.keys.RSAKey;
+import io.github.intoto.legacy.models.Link;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -29,9 +31,6 @@ import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.HttpResponse;
-
-import io.github.in_toto.models.Link;
-import io.github.in_toto.keys.RSAKey;
 
 import java.net.URI;
 import java.lang.System;

--- a/src/test/java/io/jenkins/plugins/intotorecorder/transport/RedisTestIT.java
+++ b/src/test/java/io/jenkins/plugins/intotorecorder/transport/RedisTestIT.java
@@ -6,6 +6,8 @@ package io.jenkins.plugins.intotorecorder.transport;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.util.RunList;
+import io.github.intoto.legacy.keys.RSAKey;
+import io.github.intoto.legacy.models.Link;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -22,9 +24,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-
-import io.github.in_toto.models.Link;
-import io.github.in_toto.keys.RSAKey;
 
 import java.net.URI;
 import java.lang.System;


### PR DESCRIPTION
Updated the [in-toto-java](https://github.com/in-toto/in-toto-java) dependency from 0.3 to 0.4.1
This will enable us to upgrade in-toto Jenkins plugin as it uses the newly added libraries on in-toto-java like [slsa/models](https://github.com/in-toto/in-toto-java/tree/master/src/main/java/io/github/intoto/slsa/models)