### PR TITLE
Changed Jenkinsfile to follow archetypes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(platforms: ['linux'], jdkVersions: [11])
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 11],
+])


### PR DESCRIPTION
Changes the Jenkinsfile to follow archetypes as mentioned [here](https://github.com/jenkins-infra/pipeline-library/).

I have kept jdk version as 11 and all tests have passed.